### PR TITLE
Add lint script, remove obsolete analyze

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,9 @@
     "db:setup": "node scripts/setup-database.js",
     "db:render": "node scripts/render-db-setup.js",
     "verify": "node scripts/verify-render-setup.js",
-    "analyze": "node cleanup-analysis.js",
     "cleanup": "node scripts/cleanup.js",
-    "cleanup:dry-run": "node cleanup-analysis.js",
-    "cleanup:maintenance": "node scripts/cleanup-maintenance.js"
+    "cleanup:maintenance": "node scripts/cleanup-maintenance.js",
+    "lint": "eslint ."
   },
   "keywords": [
     "ai",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,16 @@
     "db:render": "node scripts/render-db-setup.js",
     "verify": "node scripts/verify-render-setup.js",
     "cleanup": "node scripts/cleanup.js",
+  "scripts": {
     "cleanup:maintenance": "node scripts/cleanup-maintenance.js",
-    "lint": "eslint ."
+    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint ."
   },
+  "dependencies": {
+    "ws": "^8.14.2"
+  },
+  "devDependencies": {
+    "eslint": "^8.57.0"
+  }
   "keywords": [
     "ai",
     "crm",


### PR DESCRIPTION
## Summary
- add `lint` to package scripts for quick ESLint runs
- drop unused `analyze` and `cleanup:dry-run` scripts referencing missing file

## Testing
- `npm test` *(fails: Cannot find package 'node-fetch' imported from test/api.test.js)*
- `ESLINT_USE_FLAT_CONFIG=false npx eslint .` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6875b4a75aac8321b0831522f1dfc7d8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the "analyze" and "cleanup:dry-run" scripts from project scripts.
  * Added a new "lint" script to run ESLint checks on the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->